### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ You can read all about the C api provided at [the MySQL documentation site](http
 
 ## Installation
 
-mysql-connector-c can be installed using Cocoapods. Add the following declaration into your Podfile:
+mysql-connector-c can be installed using CocoaPods. Add the following declaration into your Podfile:
 
 ```ruby
 pod ‘mysql-connector-c’, ‘~> 1.0’
 ```
 
-You can also copy the files from the Sources directory into your project if you’re not using Cocoapods.
+You can also copy the files from the Sources directory into your project if you’re not using CocoaPods.
 
 ## Sample Project
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
